### PR TITLE
Adds qs-google-signature package as a replacement for querystring to …

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var qs = require('querystring'),
+var qs = require('qs-google-signature'),
     request = require('request');
 
 var DISTANCE_API_URL = 'https://maps.googleapis.com/maps/api/distancematrix/json?';
@@ -104,7 +104,7 @@ var formatResults = function(data, options, callback) {
 };
 
 var fetchData = function(options, callback) {
-  request(DISTANCE_API_URL + qs.stringify(options), function (err, res, body) {
+  request(DISTANCE_API_URL + qs.stringify(options, DISTANCE_API_URL), function (err, res, body) {
     if (!err && res.statusCode == 200) {
       var data = JSON.parse(body);
       callback(null, data);

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "api"
   ],
   "dependencies": {
+    "qs-google-signature": "^1.2.0",
     "request": "~2.34.0"
   },
   "devDependencies": {


### PR DESCRIPTION
…automatically handle URL signing for Google Maps API Premium Account users .

See https://developers.google.com/maps/documentation/directions/get-api-key#client-id